### PR TITLE
fix for condRequire in a node.js env

### DIFF
--- a/notebook.js
+++ b/notebook.js
@@ -3,6 +3,10 @@
 // notebook.js may be freely distributed under the MIT license.
 (function () {
     var root = this;
+    if ( typeof require === "function" ) {
+      root.marked = require('marked');
+      root.ansi_up = require('ansi_up');
+    }
     var VERSION = "0.2.5";
 
     // Get browser or JSDOM document
@@ -129,7 +133,7 @@
 
     nb.display.javascript = function (js) {
         var el = makeElement("script");
-        script.innerHTML = js;
+        el.innerHTML = js;
         return el;
     };
     nb.display["application/javascript"] = nb.display.javascript;

--- a/notebook.js
+++ b/notebook.js
@@ -48,8 +48,7 @@
     };
 
     var getAnsi = function () {
-        var req = condRequire("ansi_up");
-        var lib = root.ansi_up || req; 
+        var lib = root.ansi_up || condRequire("ansi_up"); 
         return lib && lib.ansi_to_html;
     };
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "contributors" : [],
     "license": "MIT",
     "dependencies" : {
-        "jsdom": ">=4.0.0",
+        "jsdom": "9.x",
         "marked": ">=0.3.3",
         "ansi_up": ">=1.1.3"
     },


### PR DESCRIPTION
Hello - We needed to use this awesome module for parsing notebook json (ipynb) on the client, but I ran into some issues with the `condRequire` method. We're using browserify right now to create a bundle and I was hoping that the conditional require would work but it didnt seem to like it since the require is invoked at build time. I ended up forking the repo and making a change so that `root` has `marked` and `ansi_up` required by default on initialization of module. The idea is that since these libs are `required` up front then they built into the bundle and all is happy. I think my solution will cover all cases though it map lend itself to being improved or cleaning up the logic with other `condRequire` calls.

I also fixed a typo where i had to s/script/el/ for displaying javascript output from the notebook.  
