### PR TITLE
Be able to configure marked.js's options for need

### DIFF
--- a/notebook.js
+++ b/notebook.js
@@ -305,6 +305,9 @@
     };
 
     nb.Notebook.prototype.render = function () {
+		if (this.config && this.config.markdown){
+			nb.markdown.setOptions(this.config.markdown);
+		}
         var notebook_el = makeElement("div", [ "notebook" ]);
         this.worksheets.forEach(function (w) {
             notebook_el.appendChild(w.render()); 


### PR DESCRIPTION
I load ipynb from the raw.githubusercontent.com/user/repo/branch/myipynb.ipynb, and the image are located base on url of **gitcontent**, We need to be able to pass de **baseUrl** or other options if we need marked.js to correctly render the image and other resources. By default the images are load relative to my website.