### PR TITLE
Include Uglify Tool in JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
     "name": "notebookjs",
-    "version": "0.6.7",
+    "version": "0.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "notebookjs",
-            "version": "0.6.7",
+            "version": "0.7.0",
             "license": "MIT",
             "dependencies": {
                 "ansi_up": "^5.0.1",
                 "dompurify": "^2.2.9",
                 "jsdom": "^16.6.0",
                 "marked": "^4.0.10"
+            },
+            "devDependencies": {
+                "uglify-js": "3.17.4"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -538,6 +541,18 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/uglify-js": {
+            "version": "3.17.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "dev": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/universalify": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -1039,6 +1054,12 @@
             "requires": {
                 "prelude-ls": "~1.1.2"
             }
+        },
+        "uglify-js": {
+            "version": "3.17.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "dev": true
         },
         "universalify": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
         "jsdom": "^16.6.0",
         "marked": "^4.0.10"
     },
+    "devDependencies": {
+        "uglify-js": "3.17.4"
+    },
     "repository": {
         "type": "git",
         "url": "git://github.com/jsvine/notebookjs.git"


### PR DESCRIPTION
The Makefile uses `uglifyjs`. It is unclear
what version of the tool should be used.
Include a version of the tool in the
package.json, so that a decent default
version is installed.

Then, you can use `npx make` to produce the
the notebook.min.js