### PR TITLE
failover to globalThis

### DIFF
--- a/notebook.js
+++ b/notebook.js
@@ -2,7 +2,7 @@
 // notebook.js may be freely distributed under the MIT license.
 (function () {
     var VERSION = "0.8.2";
-    var root = this;
+    var root = this || globalThis;
     var isBrowser = root.window !== undefined;
     var doc;
 


### PR DESCRIPTION
This small change fixes the problem I mentioned in this issue: https://github.com/jsvine/notebookjs/issues/54

There might be additional changes that would make the library even more robust; but, this one line is all I need.